### PR TITLE
Add query_log as preload library

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Check out the Makefile for other commands/shortcuts.
 
 # Resources
 - [PostgreSQL Hooks](https://github.com/AmatanHead/psql-hooks/blob/master/Detailed.md)
+- [Info about our postgres docker image](https://hub.docker.com/r/centos/postgresql-10-centos7). See `./src/contractor/extend` for an example of how to extend it

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,6 @@ services:
     - POSTGRESQL_PASSWORD=pw
     - POSTGRESQL_DATABASE=main
     - POSTGRESQL_ADMIN_PASSWORD=pw
-    #volumes:
+    volumes:
+    - ./src/contractor/extend:/opt/app-root/src
     #- ./src/contractor/query_log/query_log.c:/usr/src/query_log/query_log.c

--- a/src/contractor/extend/postgresql-cfg/extend.conf
+++ b/src/contractor/extend/postgresql-cfg/extend.conf
@@ -1,0 +1,1 @@
+shared_preload_libraries = 'query_log'


### PR DESCRIPTION
If you don't preload an extension, it won't be available unless you ran `CREATE EXTENSION query_log` in the same session or you invoked it (e.g., `select * from query_log()`) in a later session. We'll want our extensions to "do stuff" without further input from us.

Also I finally figured out how to extend the default postgres image. In this PR I only extended the default configuration, but there are similar things that we could use to initially populate tables, etc. that I've just been doing from a client (less good). More info about that in the link I put in README.